### PR TITLE
allowing nonstandard methods for tornado python client.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/python/tornado/rest.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/tornado/rest.mustache
@@ -83,7 +83,7 @@ class RESTClientObject(object):
                 "body parameter cannot be used with post_params parameter."
             )
 
-        request = httpclient.HTTPRequest(url)
+        request = httpclient.HTTPRequest(url, allow_nonstandard_methods=True)
         request.ca_certs = self.ca_certs
         request.client_key = self.client_key
         request.client_cert = self.client_cert


### PR DESCRIPTION
This should fix the delete api. 