### PR TITLE
Unicode error

### DIFF
--- a/modules/swagger-codegen/src/main/resources/python/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api_client.mustache
@@ -547,7 +547,7 @@ class ApiClient(object):
         try:
             return klass(data)
         except UnicodeEncodeError:
-            return six.u(data)
+            return u"".join(data).encode("utf-8")
         except TypeError:
             return data
 

--- a/modules/swagger-codegen/src/main/resources/python/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api_client.mustache
@@ -547,7 +547,7 @@ class ApiClient(object):
         try:
             return klass(data)
         except UnicodeEncodeError:
-            return u"".join(data).encode("utf-8")
+            return six.text_type(data)
         except TypeError:
             return data
 

--- a/samples/client/petstore-security-test/python/petstore_api/api_client.py
+++ b/samples/client/petstore-security-test/python/petstore_api/api_client.py
@@ -541,7 +541,7 @@ class ApiClient(object):
         try:
             return klass(data)
         except UnicodeEncodeError:
-            return six.u(data)
+            return u"".join(data).encode("utf-8")
         except TypeError:
             return data
 

--- a/samples/client/petstore-security-test/python/petstore_api/api_client.py
+++ b/samples/client/petstore-security-test/python/petstore_api/api_client.py
@@ -541,7 +541,7 @@ class ApiClient(object):
         try:
             return klass(data)
         except UnicodeEncodeError:
-            return u"".join(data).encode("utf-8")
+            return six.text_type(data)
         except TypeError:
             return data
 

--- a/samples/client/petstore/python-asyncio/petstore_api/api_client.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api_client.py
@@ -541,7 +541,7 @@ class ApiClient(object):
         try:
             return klass(data)
         except UnicodeEncodeError:
-            return six.u(data)
+            return u"".join(data).encode("utf-8")
         except TypeError:
             return data
 

--- a/samples/client/petstore/python-asyncio/petstore_api/api_client.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api_client.py
@@ -541,7 +541,7 @@ class ApiClient(object):
         try:
             return klass(data)
         except UnicodeEncodeError:
-            return u"".join(data).encode("utf-8")
+            return six.text_type(data)
         except TypeError:
             return data
 

--- a/samples/client/petstore/python-tornado/petstore_api/api_client.py
+++ b/samples/client/petstore/python-tornado/petstore_api/api_client.py
@@ -543,7 +543,7 @@ class ApiClient(object):
         try:
             return klass(data)
         except UnicodeEncodeError:
-            return u"".join(data).encode("utf-8")
+            return six.text_type(data)
         except TypeError:
             return data
 

--- a/samples/client/petstore/python-tornado/petstore_api/api_client.py
+++ b/samples/client/petstore/python-tornado/petstore_api/api_client.py
@@ -543,7 +543,7 @@ class ApiClient(object):
         try:
             return klass(data)
         except UnicodeEncodeError:
-            return six.u(data)
+            return u"".join(data).encode("utf-8")
         except TypeError:
             return data
 

--- a/samples/client/petstore/python/petstore_api/api_client.py
+++ b/samples/client/petstore/python/petstore_api/api_client.py
@@ -541,7 +541,7 @@ class ApiClient(object):
         try:
             return klass(data)
         except UnicodeEncodeError:
-            return six.u(data)
+            return u"".join(data).encode("utf-8")
         except TypeError:
             return data
 

--- a/samples/client/petstore/python/petstore_api/api_client.py
+++ b/samples/client/petstore/python/petstore_api/api_client.py
@@ -541,7 +541,7 @@ class ApiClient(object):
         try:
             return klass(data)
         except UnicodeEncodeError:
-            return u"".join(data).encode("utf-8")
+            return six.text_type(data)
         except TypeError:
             return data
 


### PR DESCRIPTION
This will fix the issue of "decoding Unicode is not supported" error in py2 when the input to _six.u_ method is Unicode.
If UnicodeEncodeError comes, it is highly likely the code is dealing with Unicode string. _six.u_ does not allow Unicode input but only string literal and breaks the logic. 